### PR TITLE
Improve todo UI and turbo workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -2,6 +2,7 @@ class TodosController < ApplicationController
   before_action :set_todo, only: %i[update destroy]
 
   def index
+    @todo = Todo.new
     @todos = Todo.recent
   end
 
@@ -10,13 +11,40 @@ class TodosController < ApplicationController
 
     if @todo.save
       respond_to do |format|
-        format.turbo_stream { render turbo_stream: turbo_stream.append("todos", @todo) }
-        format.html { redirect_to todos_path }
+        format.turbo_stream do
+          render turbo_stream: [
+            turbo_stream.prepend(
+              "todos",
+              partial: "todos/todo",
+              locals: { todo: @todo }
+            ),
+            turbo_stream.replace(
+              "empty_state",
+              partial: "todos/empty_state",
+              locals: { todos_present: Todo.exists? }
+            ),
+            turbo_stream.replace(
+              "todo_form",
+              partial: "todos/form",
+              locals: { todo: Todo.new }
+            )
+          ]
+        end
+        format.html { redirect_to todos_path, notice: "Todo was successfully created." }
       end
     else
       respond_to do |format|
-        format.turbo_stream { head :unprocessable_entity }
-        format.html { redirect_to todos_path, alert: @todo.errors.full_messages.join(", ") }
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            "todo_form",
+            partial: "todos/form",
+            locals: { todo: @todo }
+          ), status: :unprocessable_entity
+        end
+        format.html do
+          redirect_to todos_path, status: :see_other,
+                                  alert: @todo.errors.full_messages.to_sentence
+        end
       end
     end
   end
@@ -39,8 +67,17 @@ class TodosController < ApplicationController
     @todo.destroy
 
     respond_to do |format|
-      format.turbo_stream { render turbo_stream: turbo_stream.remove(@todo) }
-      format.html { redirect_to todos_path }
+      format.turbo_stream do
+        render turbo_stream: [
+          turbo_stream.remove(@todo),
+          turbo_stream.replace(
+            "empty_state",
+            partial: "todos/empty_state",
+            locals: { todos_present: Todo.exists? }
+          )
+        ]
+      end
+      format.html { redirect_to todos_path, notice: "Todo was successfully removed." }
     end
   end
 

--- a/app/views/todos/_empty_state.html.erb
+++ b/app/views/todos/_empty_state.html.erb
@@ -1,0 +1,8 @@
+<% if todos_present %>
+  <!-- When todos exist, this frame remains empty so Turbo can replace it -->
+<% else %>
+  <div class="flex flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+    <p class="text-lg font-semibold text-slate-700">No todos yet</p>
+    <p class="text-sm text-slate-500">Get started by creating a new todo</p>
+  </div>
+<% end %>

--- a/app/views/todos/_form.html.erb
+++ b/app/views/todos/_form.html.erb
@@ -5,10 +5,38 @@
     controller: "reset-form",
     action: "turbo:submit-end->reset-form#reset"
   }) do |form| %>
-  <%= form.text_field :title,
-      placeholder: "What needs to be done?",
-      class: "block w-full rounded-lg shadow-sm bg-white py-3 px-4",
-      required: true,
-      autofocus: true,
-      maxlength: 255 %>
+  <div class="space-y-4">
+    <% if form.object.errors.any? %>
+      <div class="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        <p class="font-semibold">There was a problem saving your todo:</p>
+        <ul class="mt-2 list-disc space-y-1 pl-5">
+          <% form.object.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div>
+      <%= form.label :title, "What needs to be done?", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_field :title,
+          placeholder: "What needs to be done?",
+          class: "mt-1 block w-full rounded-lg border border-slate-200 bg-white py-3 px-4 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200",
+          required: true,
+          autofocus: true,
+          maxlength: 255 %>
+    </div>
+
+    <div>
+      <%= form.label :description, "Add a description (optional)", class: "block text-sm font-medium text-slate-700" %>
+      <%= form.text_area :description,
+          rows: 3,
+          class: "mt-1 block w-full rounded-lg border border-slate-200 bg-white py-2 px-4 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200",
+          maxlength: 1000 %>
+    </div>
+
+    <div class="flex justify-end">
+      <%= form.submit "Add Todo", class: "inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700" %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -14,8 +14,16 @@
     <%= tag.span(
       todo.title,
       class: class_names(
-        "text-slate-700" => !todo.completed?,
+        "text-slate-700 font-medium" => !todo.completed?,
         "line-through text-slate-400" => todo.completed?
       )) %>
+
+    <% if todo.description.present? %>
+      <%= tag.p(
+        todo.description,
+        class: "mt-1 text-sm text-slate-500",
+        data: { test_id: "todo-description" }
+      ) %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -5,10 +5,11 @@
       todo.completed?,
       class: "h-5 w-5 text-blue-600 rounded-lg focus:ring-blue-500 cursor-pointer",
       data: {
-      controller: "todo-checkbox",
-      action: "change->todo-checkbox#toggle",
-      todo_id: todo.id
-    } %>
+        turbo_permanent: true,
+        controller: "todo-checkbox",
+        action: "change->todo-checkbox#toggle",
+        todo_id: todo.id
+      } %>
   </div>
   <div class="flex-1 min-w-0">
     <%= tag.span(

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -4,6 +4,7 @@
       todo.id,
       todo.completed?,
       class: "h-5 w-5 text-blue-600 rounded-lg focus:ring-blue-500 cursor-pointer",
+      id: dom_id(todo, :completed),
       data: {
         turbo_permanent: true,
         controller: "todo-checkbox",

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -1,9 +1,24 @@
 <%= turbo_stream_from "todos" %>
 
-<div class="mb-3">
-  <%= render "form", todo: Todo.new %>
-</div>
+<div class="space-y-6">
+  <header class="flex flex-col gap-2">
+    <h1 class="text-3xl font-semibold text-slate-900">My Todos</h1>
+    <p class="text-slate-500">Keep track of everything you need to get done.</p>
+  </header>
 
-<div class="overflow-hidden divide-y divide-slate-200 rounded-lg shadow-sm" id="todos">
-  <%= render @todos %>
+  <div class="rounded-lg border border-slate-200 bg-slate-50 p-6 shadow-sm">
+    <%= turbo_frame_tag "todo_form" do %>
+      <%= render "form", todo: @todo %>
+    <% end %>
+  </div>
+
+  <div class="rounded-lg border border-slate-200 bg-white shadow-sm">
+    <div class="divide-y divide-slate-200" id="todos">
+      <%= render @todos %>
+    </div>
+
+    <%= turbo_frame_tag "empty_state" do %>
+      <%= render "empty_state", todos_present: @todos.any? %>
+    <% end %>
+  </div>
 </div>

--- a/docs/postgresql_setup.md
+++ b/docs/postgresql_setup.md
@@ -1,0 +1,18 @@
+# PostgreSQL Setup in Development Container
+
+PostgreSQL 16 is installed in the development container via `apt-get` and
+started with the default cluster tooling that ships with the package. The full
+sequence of commands that were executed is recorded below:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y postgresql postgresql-contrib
+sudo -u postgres pg_ctlcluster 16 main start
+sudo -u postgres createuser -s root
+sudo -u postgres psql -c "SELECT version();"
+bundle exec rails db:setup
+```
+
+Running `bundle exec rails db:setup` now succeeds and provisions the
+`todos_development`, `todos_development_cache`, and `todos_test` databases using
+the newly created `root` role.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,21 @@
 require 'capybara/rspec'
+require 'tmpdir'
+require 'securerandom'
+
+Capybara.register_driver :selenium_chrome_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless=new')
+  options.add_argument('--disable-gpu')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,900')
+  user_data_dir = Dir.mktmpdir("chrome-user-data-#{SecureRandom.hex(8)}")
+  options.add_argument("--user-data-dir=#{user_data_dir}")
+  options.add_argument('--no-first-run')
+  options.add_argument('--no-default-browser-check')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
 
 RSpec.configure do |config|
   # Use rack_test driver by default (faster, no JS)


### PR DESCRIPTION
## Summary
- update the todos controller to prepend new records, reset the form, and toggle the empty-state stream when items are created or removed
- refresh the index page with a heading, validated form, todo descriptions, and an empty-state partial for better UX
- configure a custom headless Chrome driver that isolates user data directories so JavaScript system specs can run reliably

## Testing
- bundle exec rspec

------
https://chatgpt.com/codex/tasks/task_e_68fd31a28a1083229747eb953b3daa54